### PR TITLE
Load json with utf-8 encoding

### DIFF
--- a/python/src/posteriordb/posterior_database.py
+++ b/python/src/posteriordb/posterior_database.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 
 def load_json_file(filepath):
-    with open(filepath) as f:
+    with open(filepath, encoding="utf-8") as f:
         return json.load(f)
 
 


### PR DESCRIPTION
This fixes the error with special characters.

I think the default encoding on Windows is not utf-8 which might cause this problem where special characters have wrong char.